### PR TITLE
Change hostname to poll winner

### DIFF
--- a/lua/sv-tas-utils/initpostentity/namechanger.lua
+++ b/lua/sv-tas-utils/initpostentity/namechanger.lua
@@ -29,7 +29,10 @@ local function getFormattedHostname(message)
 	---@type string
 	local region = SV_LOCATION_CONVAR:GetString():upper()
 
-	return NAME_FORMAT:gsub("${region}", region):gsub("${message}", message)
+	-- Redundant local to avoid returning gsub count
+	local formatted = NAME_FORMAT:gsub("${region}", region)
+		:gsub("${message}", message)
+	return formatted
 end
 
 for _, message in ipairs(MESSAGES) do


### PR DESCRIPTION
# Changes

- Refactors server name changer to improve code quality
- Changes hostname format to [poll winner](https://discord.com/channels/800234484649820163/1127560228888662056/1161012658665955398)

# Impact

New format provides a number of benefits over the previous hostname:

- Including the `TAS` acronym makes it easier for existing users to search for our servers
- Renaming `Total Anarchy Server` to `Total Anarchy Servers` communicates that we're now not a single server
- Adding the location code to the name distinguishes between UK and Canadian servers
- SEO tags are updated to be shorter but more impactful (no one is searching for client-side Lua support)