### PR TITLE
[Experiment] Hide ULX command messages

### DIFF
--- a/lua/sv-tas-utils/initpostentity/hideulxcommands.lua
+++ b/lua/sv-tas-utils/initpostentity/hideulxcommands.lua
@@ -1,5 +1,7 @@
+if not ULib or not ULib.sayCmds then
+	return
+end
 
-if not ULib or not ULib.sayCmds then return end
 for _, c in pairs(ULib.sayCmds) do
 	c.hide = true
 end

--- a/lua/sv-tas-utils/initpostentity/hideulxcommands.lua
+++ b/lua/sv-tas-utils/initpostentity/hideulxcommands.lua
@@ -1,0 +1,5 @@
+
+if not ULib or not ULib.sayCmds then return end
+for _, c in pairs(ULib.sayCmds) do
+	c.hide = true
+end


### PR DESCRIPTION
Hides ULX command messages, eg. `!whip ^ 10` while still retaining ULX FancyLog messages, ie. `You whipped Yourself 10 times with 0 damage`.