### PR TITLE
Better alias for `!cleanupdiscon`

### DIFF
--- a/lua/ulx/modules/sh/cleanupdiscon.lua
+++ b/lua/ulx/modules/sh/cleanupdiscon.lua
@@ -10,7 +10,7 @@ local cleanupCmd = ulx.command(
 			"#A cleaned up disconnected players props"
 		)
 	end,
-	"!cleanupdiscon"
+	{ "!cleanupdiscon", "!cleanupdc" }
 )
 cleanupCmd:defaultAccess(ULib.ACCESS_ADMIN)
 cleanupCmd:help("Removes all props owned by disconnected players")


### PR DESCRIPTION
I don't know who came up with that name, it should obviously be `!cleanupdc` or even `!cleandc`.
Keeping the old name for compatibility, this is just an alias.