### PR TITLE
Refactor Better ChatPrint and fix size limit

### DIFF
--- a/lua/sh-tas-utils/betterchatprint.lua
+++ b/lua/sh-tas-utils/betterchatprint.lua
@@ -25,7 +25,7 @@ if SERVER then
 			if IsColor(v) then
 				size = size + COLOUR_CHANNEL_BITS * 3
 			else
-				size = size + #tostring(v) + NULL_TERMINATOR_BITS
+				size = size + #tostring(v) * 8 + NULL_TERMINATOR_BITS
 			end
 		end
 

--- a/lua/sh-tas-utils/betterchatprint.lua
+++ b/lua/sh-tas-utils/betterchatprint.lua
@@ -1,48 +1,107 @@
+local ARGS_LENGTH_BITS = 8
+local BOOLEAN_BITS = 1
+local COLOUR_CHANNEL_BITS = 8
+local NULL_TERMINATOR_BITS = 8
+
+local MAX_MESSAGE_SIZE_BITS = 4 * 1024 * 8
+local MAX_ARGS = 2 ^ ARGS_LENGTH_BITS - 1
+
 if SERVER then
 	util.AddNetworkString("TASUtils.ChatPrint")
 
-	local function encodeMsg(args)
-		for _, v in ipairs(args) do
+	--- Returns the size of a chat print net message in bits
+	---@param args any[]
+	---@return integer
+	function TASUtils.getChatPrintMessageSizeBits(args)
+		local size = ARGS_LENGTH_BITS
+
+		for i, v in ipairs(args) do
+			if i > MAX_ARGS then
+				break
+			end
+
+			size = size + BOOLEAN_BITS
+
+			if IsColor(v) then
+				size = size + COLOUR_CHANNEL_BITS * 3
+			else
+				size = size + #tostring(v) + NULL_TERMINATOR_BITS
+			end
+		end
+
+		return size
+	end
+
+	local function writeMessage(args)
+		net.WriteUInt(#args, ARGS_LENGTH_BITS)
+
+		for i, v in ipairs(args) do
+			if i > MAX_ARGS then
+				break
+			end
+
 			local isColor = IsColor(v)
 			net.WriteBool(isColor)
 
 			if isColor then
-				net.WriteColor(v, false)
+				net.WriteUInt(v.r, COLOUR_CHANNEL_BITS)
+				net.WriteUInt(v.g, COLOUR_CHANNEL_BITS)
+				net.WriteUInt(v.b, COLOUR_CHANNEL_BITS)
 			else
 				net.WriteString(tostring(v))
 			end
 		end
+	end
 
-		if net.BytesWritten() > 1024 * 64 then
-			error("Tried to send too much data", 3)
+	local function assertMessageSize(args)
+		local messageSize = TASUtils.getChatPrintMessageSizeBits(args)
+		if messageSize > MAX_MESSAGE_SIZE_BITS then
+			error(
+				string.format(
+					"Message size %d is greater than maximum of %d bits",
+					messageSize,
+					MAX_MESSAGE_SIZE_BITS
+				),
+				2
+			)
 		end
 	end
 
-	-- Takes a vararg of colours and things to print (each item must have a valid tostring metamethod present)
+	--- Takes a vararg of colours and things to print (each item must have a valid tostring metamethod)
+	---@param ... any
 	function TASUtils.Broadcast(...)
 		local args = { ... }
 
+		assertMessageSize(args)
+
 		net.Start("TASUtils.ChatPrint")
-		net.WriteUInt(#args, 16)
-		encodeMsg({ ... })
+		writeMessage(args)
 		net.Broadcast()
 	end
 
 	FindMetaTable("Player").ChatPrint = function(self, ...)
 		local args = { ... }
 
+		assertMessageSize(args)
+
 		net.Start("TASUtils.ChatPrint")
-		net.WriteUInt(#args, 16)
-		encodeMsg({ ... })
+		writeMessage(args)
 		net.Send(self)
 	end
 else
 	net.Receive("TASUtils.ChatPrint", function()
 		local args = {}
 
-		for i = 1, net.ReadUInt(16) do
-			args[i] = net.ReadBool() and net.ReadColor(false)
-				or net.ReadString()
+		for i = 1, net.ReadUInt(ARGS_LENGTH_BITS) do
+			if net.ReadBool() then
+				args[i] = Color(
+					net.ReadUInt(COLOUR_CHANNEL_BITS),
+					net.ReadUInt(COLOUR_CHANNEL_BITS),
+					net.ReadUInt(COLOUR_CHANNEL_BITS)
+				)
+			else
+				args[i] = net.ReadString()
+			end
 		end
 
 		-- Display the parsed message


### PR DESCRIPTION
# Changes

- Adds a new `TASUtils.getChatPrintMessageSizeBits` global to calculate the size of a chat print message before trying to send
- Refactors `encodeMsg` to have a clearer name and to not check the message size mid-send
- Updates `Broadcast` and `ChatPrint` functions to check the message size and error before starting the netmsg
- Replaces `net.WriteColor` with `net.WriteUInt`
  - `WriteColor` uses `WriteUInt` under the hood, but this way we ignore some useless checks and have confidence in parity between our writer and size calculator functions
- Reduces max message size to 4KB

# Impact

- Properly prevents overflowing net messages
- Exposes the size calculation func which allows for upcoming plycore changes to throw E2 errors when the message is too large

# Testing

`TASUtils.Broadcast` and `Player:ChatPrint()` are essentially the same code, so can fully test one and then smoke test the other

- Calling with no arguments prints an empty string to chat
- Calling with one or more strings prints those strings to chat
- Calling with colours and strings correctly colours the `chat.AddText` message
- Arguments that are neither colours nor strings are stringified
- Throws an error when the total message is larger than 4KB
- Passing more than 255 arguments truncates to 255